### PR TITLE
Add lifecycleHandlers keytree and symbolic functions for listening on bound/unbound

### DIFF
--- a/can-event-queue.js
+++ b/can-event-queue.js
@@ -43,8 +43,6 @@ var ensureMeta = function ensureMeta(obj) {
 	var lifecycleHandlers = meta.lifecycleHandlers;
 	if(!lifecycleHandlers) {
 		// lifecycleHandlers are organized by:
-		// event name - the type of event bound to
-		// binding type - "event" for things that expect an event object (legacy), "onKeyValue" for reflective bindings.
 		// queue name - mutate, queue, etc
 		// lifecycleHandlers - the lifecycleHandlers.
 		lifecycleHandlers = meta.lifecycleHandlers = new KeyTree([Object, Array]);

--- a/can-event-queue.js
+++ b/can-event-queue.js
@@ -25,36 +25,53 @@ var ensureMeta = function ensureMeta(obj) {
 // getHandlers returns a KeyTree used for event handling.
 // `handlers` will be on the `can.meta` symbol on the object.
 function getHandlers(obj) {
-    var meta = ensureMeta(obj);
+	var meta = ensureMeta(obj);
 
-    var handlers = meta.handlers;
-    if(!handlers) {
-        // Handlers are organized by:
-        // event name - the type of event bound to
-        // binding type - "event" for things that expect an event object (legacy), "onKeyValue" for reflective bindings.
-        // queue name - mutate, queue, etc
-        // handlers - the handlers.
-        handlers = meta.handlers = new KeyTree([Object, Object, Object, Array],{
-            onFirst: function(){
-                if( obj._eventSetup ) {
-                    obj._eventSetup();
-                }
-            },
-            onEmpty: function(){
-                if( obj._eventTeardown ) {
-                    obj._eventTeardown();
-                }
-            }
-        });
-    }
-    return handlers;
+	var handlers = meta.handlers;
+	if(!handlers) {
+		// Handlers are organized by:
+		// event name - the type of event bound to
+		// binding type - "event" for things that expect an event object (legacy), "onKeyValue" for reflective bindings.
+		// queue name - mutate, queue, etc
+		// handlers - the handlers.
+		handlers = meta.handlers = new KeyTree([Object, Object, Object, Array],{
+			onFirst: function(){
+				if( obj._eventSetup ) {
+					obj._eventSetup();
+				}
+				dispatchOnKeyTree(obj, getMetaHandlers(obj), "boundChange", [true]);
+			},
+			onEmpty: function(){
+				if( obj._eventTeardown ) {
+					obj._eventTeardown();
+				}
+				dispatchOnKeyTree(obj, getMetaHandlers(obj), "boundChange", [false]);
+			}
+		});
+	}
+	return handlers;
 }
 
-// These are the properties we are going to add to objects
-var props = {
-	dispatch: function(event, args){
+// getMetaHandlers returns a KeyTree used for handling internal events (like handling first binding).
+// `metaHandlers` will be on the `can.meta` symbol on the object.
+function getMetaHandlers(obj) {
+	var meta = ensureMeta(obj);
+
+	var metaHandlers = meta.metaHandlers;
+	if(!metaHandlers) {
+		// metaHandlers are organized by:
+		// event name - the type of event bound to
+		// binding type - "event" for things that expect an event object (legacy), "onKeyValue" for reflective bindings.
+		// queue name - mutate, queue, etc
+		// metaHandlers - the metaHandlers.
+		metaHandlers = meta.metaHandlers = new KeyTree([Object, Object, Object, Array]);
+	}
+	return metaHandlers;
+}
+
+function dispatchOnKeyTree(obj, keyTree, event, args){
 		//!steal-remove-start
-		if (arguments.length > 2) {
+		if (arguments.length > 4) {
 			canDev.warn('Arguments to dispatch should be an array, not multiple arguments.');
 			args = Array.prototype.slice.call(arguments, 1);
 		}
@@ -66,7 +83,7 @@ var props = {
 		//!steal-remove-end
 
 		// Don't send events if initalizing.
-		if (!this.__inSetup) {
+		if (!obj.__inSetup) {
 			if(typeof event === 'string') {
 				event = {
 					type: event
@@ -75,7 +92,7 @@ var props = {
 
 			//!steal-remove-start
 			if (!event.reasonLog) {
-				event.reasonLog = [ canReflect.getName(this), "dispatched", '"' + event + '"', "with" ].concat(args);
+				event.reasonLog = [ canReflect.getName(obj), "dispatched", '"' + event + '"', "with" ].concat(args);
 			}
 			if (!event.makeMeta) {
 				event.makeMeta = function makeMeta(handler) {
@@ -85,28 +102,32 @@ var props = {
 				};
 			}
 
-			var meta = ensureMeta(this);
+			var meta = ensureMeta(obj);
 			if (typeof meta._log === "function") {
-				meta._log.call(this, event, args);
+				meta._log.call(obj, event, args);
 			}
 			//!steal-remove-end
 
-			var handlers = getHandlers(this);
-			var handlersByType = handlers.getNode([event.type]);
+			var handlersByType = keyTree.getNode([event.type]);
 			if(handlersByType) {
 				queues.batch.start();
 				if(handlersByType.onKeyValue) {
-					queues.enqueueByQueue(handlersByType.onKeyValue, this, args, event.makeMeta, event.reasonLog);
+					queues.enqueueByQueue(handlersByType.onKeyValue, obj, args, event.makeMeta, event.reasonLog);
 				}
 				if(handlersByType.event) {
 
 					event.batchNum = queues.batch.number();
 					var eventAndArgs = [event].concat(args);
-					queues.enqueueByQueue(handlersByType.event, this, eventAndArgs, event.makeMeta, event.reasonLog);
+					queues.enqueueByQueue(handlersByType.event, obj, eventAndArgs, event.makeMeta, event.reasonLog);
 				}
 				queues.batch.stop();
 			}
 		}
+	}
+// These are the properties we are going to add to objects
+var props = {
+	dispatch: function(event, args) {
+		return dispatchOnKeyTree(this, getHandlers(this), event, args);
 	},
 	addEventListener: function(key, handler, queueName) {
 		getHandlers(this).add([key, "event",queueName || "mutate", handler]);
@@ -117,11 +138,11 @@ var props = {
 };
 
 var onKeyValueSymbol = canSymbol.for("can.onKeyValue"),
-    offKeyValueSymbol = canSymbol.for("can.offKeyValue"),
-    onEventSymbol = canSymbol.for("can.onEvent"),
-    offEventSymbol = canSymbol.for("can.offEvent"),
-    onValueSymbol = canSymbol.for("can.onValue"),
-    offValueSymbol = canSymbol.for("can.offValue");
+	offKeyValueSymbol = canSymbol.for("can.offKeyValue"),
+	onEventSymbol = canSymbol.for("can.onEvent"),
+	offEventSymbol = canSymbol.for("can.offEvent"),
+	onValueSymbol = canSymbol.for("can.onValue"),
+	offValueSymbol = canSymbol.for("can.offValue");
 
 props.on = function(eventName, handler, queue) {
 	var listenWithDOM = domEvents.canAddEventListener.call(this);
@@ -169,23 +190,32 @@ props.off = function(eventName, handler, queue) {
 	}
 };
 
-// The symbols we'll add to bojects
+// The symbols we'll add to objects
 var symbols = {
-    "can.onKeyValue": function(key, handler, queueName) {
-        getHandlers(this).add([key, "onKeyValue",queueName || "mutate", handler]);
-    },
-    "can.offKeyValue": function(key, handler, queueName) {
-        getHandlers(this).delete([key, "onKeyValue", queueName || "mutate", handler]);
-    }
+	"can.onKeyValue": function(key, handler, queueName) {
+		getHandlers(this).add([key, "onKeyValue",queueName || "mutate", handler]);
+	},
+	"can.offKeyValue": function(key, handler, queueName) {
+		getHandlers(this).delete([key, "onKeyValue", queueName || "mutate", handler]);
+	},
+	"can.onBoundChange": function(handler, queueName) {
+		getMetaHandlers(this).add(["boundChange", "onKeyValue",queueName || "mutate", handler]);
+	},
+	"can.offBoundChange": function(handler, queueName) {
+		getMetaHandlers(this).delete(["boundChange", "onKeyValue", queueName || "mutate", handler]);
+	},
+	"can.isBound": function() {
+		return getHandlers(this).size() > 0;
+	}
 };
 
 // The actual eventQueue mixin function
 var eventQueue = function(obj) {
-    // add properties
-    assign(obj, props);
-    // add symbols
-    canReflect.assignSymbols(obj, symbols);
-    return obj;
+	// add properties
+	assign(obj, props);
+	// add symbols
+	canReflect.assignSymbols(obj, symbols);
+	return obj;
 };
 
 
@@ -194,38 +224,38 @@ var eventQueue = function(obj) {
 // The following is for compatability with the old can-event/batch
 // This can be removed in a future version.
 function defineNonEnumerable(obj, prop, value) {
-    Object.defineProperty(obj, prop, {
-    	enumerable: false,
-    	value: value
-    });
+	Object.defineProperty(obj, prop, {
+		enumerable: false,
+		value: value
+	});
 }
 
 assign(eventQueue, props);
 defineNonEnumerable(eventQueue,"start", function(){
-    console.warn("use can-queues.batch.start()");
-    queues.batch.start();
+	console.warn("use can-queues.batch.start()");
+	queues.batch.start();
 });
 defineNonEnumerable(eventQueue,"stop", function(){
-    console.warn("use can-queues.batch.stop()");
-    queues.batch.stop();
+	console.warn("use can-queues.batch.stop()");
+	queues.batch.stop();
 });
 defineNonEnumerable(eventQueue,"flush", function(){
-    console.warn("use can-queues.flush()");
-    queues.flush();
+	console.warn("use can-queues.flush()");
+	queues.flush();
 });
 
 defineNonEnumerable(eventQueue,"afterPreviousEvents", function(handler){
-    console.warn("don't use afterPreviousEvents");
-    queues.mutateQueue.enqueue(function afterPreviousEvents(){
-        queues.mutateQueue.enqueue(handler);
-    });
-    queues.flush();
+	console.warn("don't use afterPreviousEvents");
+	queues.mutateQueue.enqueue(function afterPreviousEvents(){
+		queues.mutateQueue.enqueue(handler);
+	});
+	queues.flush();
 });
 
 defineNonEnumerable(eventQueue,"after", function(handler){
-    console.warn("don't use after");
-    queues.mutateQueue.enqueue(handler);
-    queues.flush();
+	console.warn("don't use after");
+	queues.mutateQueue.enqueue(handler);
+	queues.flush();
 });
 
 module.exports = eventQueue;


### PR DESCRIPTION
This goes along with upcoming changes for can-reflect that will include the symbolic functions `@@can.onBoundChange`, `@@can.offBoundChange`, and `@@can.isBound`, which listen for or report the state of other events being bound (this is why we needed to have metaHandlers, since `onBoundChange` wouldn't be effective if it were counting its own listeners).

```js
var obj = eventQueue({});
obj[canSymbol.for("can.onBoundChange")](function(newVal) { /* true for now listening, false for not listening */ });
obj[canSymbol.for("can.isBound")](); // -> false
obj.on("foo", function() {});
obj[canSymbol.for("can.isBound")](); // -> true
```