### PR TITLE
update README.md to match current template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,25 @@
 # can-event-queue
 
-[![Build Status](https://travis-ci.org/canjs/can-event-queue.svg?branch=master)](https://travis-ci.org/canjs/can-event-queue)
+[![Join the chat at https://gitter.im/canjs/canjs](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/canjs/canjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/canjs/can-event-queue/blob/79658ab4f6342517e2453ccaf8b15d3de6960758/LICENSE)
+[![npm version](https://badge.fury.io/js/can-event-queue.svg)](https://www.npmjs.com/package/can-event-queue)
+[![Travis build status](https://travis-ci.org/canjs/can-event-queue.svg?branch=master)](https://travis-ci.org/canjs/can-event-queue)
+[![Greenkeeper badge](https://badges.greenkeeper.io/canjs/can-event-queue.svg)](https://greenkeeper.io/)
 
 `can-event-queue` mixes in event binding and dispatching methods that
 use [can-queues](../can-queues).  This adds legacy binding methods `addEventListener`
 and `removeEventListener`.  This package should not be used for new packages.
 
+Read the [can-event-queue API docs on CanJS.com](https://canjs.com/doc/can-event-queue.html).
 
-## Use
+## Changelog
 
-```js
-import eventQueue from "can-event-queue";
+See the [latest can-event-queue releases on GitHub](https://github.com/canjs/can-event-queue/releases).
 
-const obj = eventQueue( obj );
+## Contributing
 
-// obj now has `.on`, `.dispatch`, `.addEventListener` methods
-// as well as `can.onKeyValue` and `can.offKeyValue` symbols.
+The [contribution guide](https://github.com/canjs/can-event-queue/blob/master/CONTRIBUTING.md) has information on getting help, reporting bugs, developing locally, and more.
 
+## License
 
-obj.on( "event", function() {
-	console.log( "event fired!" );
-} );
-
-obj.dispatch( "event" );
-```
-
-Critically, event handlers can be registered to run in different queues.
-
-```js
-const obj = eventQueue( obj );
-
-obj.on( "event", function mutateHandler() {
-	console.log( "mutate" );
-}, "mutate" );
-
-
-obj.on( "event", function() {
-	console.log( "notify" );
-}, "notify" );
-
-obj.dispatch( "event" ); // logs "notify" then "mutate" because notify comes first
-```
+[MIT](https://github.com/canjs/can-event-queue/blob/master/LICENSE)


### PR DESCRIPTION
`can-event-queue` had an old style readme with outdate example code. This updates to the latest style directing users to the current docs.