### PR TITLE
Read from Symbol instead of __inSetup property

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -228,7 +228,7 @@ var props = {
 		//!steal-remove-end
 
 		// Don't send events if initalizing.
-		if (!this.__inSetup || !this[inSetupSymbol]) {
+		if (this.__inSetup !== true && this[inSetupSymbol] !== true) {
 			if (typeof event === 'string') {
 				event = {
 					type: event

--- a/map/map.js
+++ b/map/map.js
@@ -58,7 +58,8 @@ var metaSymbol = canSymbol.for("can.meta"),
 	onEventSymbol = canSymbol.for("can.onEvent"),
 	offEventSymbol = canSymbol.for("can.offEvent"),
 	onValueSymbol = canSymbol.for("can.onValue"),
-	offValueSymbol = canSymbol.for("can.offValue");
+	offValueSymbol = canSymbol.for("can.offValue"),
+	inSetupSymbol = canSymbol.for("can.initializing");
 
 var legacyMapBindings;
 
@@ -227,7 +228,7 @@ var props = {
 		//!steal-remove-end
 
 		// Don't send events if initalizing.
-		if (!this.__inSetup) {
+		if (!this[inSetupSymbol]) {
 			if (typeof event === 'string') {
 				event = {
 					type: event

--- a/map/map.js
+++ b/map/map.js
@@ -228,7 +228,7 @@ var props = {
 		//!steal-remove-end
 
 		// Don't send events if initalizing.
-		if (!this[inSetupSymbol]) {
+		if (!this.__inSetup || !this[inSetupSymbol]) {
 			if (typeof event === 'string') {
 				event = {
 					type: event


### PR DESCRIPTION
Part of the cleanup to remove the `__inSetup` property, in favour of the Symbol.

Ref - https://github.com/canjs/canjs/issues/4705